### PR TITLE
Fix variable reference and check that logging is enabled

### DIFF
--- a/src/lambdaisland/glogi.cljs
+++ b/src/lambdaisland/glogi.cljs
@@ -33,7 +33,7 @@
   (^Logger [n]
    (glog/getLogger (name-str n)))
   (^Logger [n level]
-   (glog/getLogger (name-str name) level)))
+   (glog/getLogger (name-str n) level)))
 
 (def ^Logger root-logger (logger ""))
 

--- a/src/lambdaisland/glogi.cljs
+++ b/src/lambdaisland/glogi.cljs
@@ -75,8 +75,10 @@
   ([name lvl message]
    (log name lvl message nil))
   ([name lvl message exception]
-   (.logRecord (logger name)
-               (make-log-record (level lvl) message name exception))))
+   (when glog/ENABLED
+     (if-let [l (logger name)]
+       (.logRecord l
+                   (make-log-record (level lvl) message name exception))))))
 
 (defn set-level
   "Set the level (a keyword) of the given logger, identified by name."


### PR DESCRIPTION
It seems that the arity-2 overload of `logger` references `cljs.core/name` instead of its parameter `n` by accident.