### PR TITLE
Fix single-argument lambdaisland.glogi/logger erasing logger level

### DIFF
--- a/src/lambdaisland/glogi.cljs
+++ b/src/lambdaisland/glogi.cljs
@@ -61,7 +61,7 @@
   "Get a logger by name, and optionally set its level. Name can be a string
   keyword, or symbol. The special keyword :glogi/root returns the root logger."
   ([n]
-   (glog/getLogger (name-str n) nil))
+   (glog/getLogger (name-str n) js/undefined))
   ([n level]
    (glog/getLogger (name-str n) level)))
 


### PR DESCRIPTION
Hi, the new version of `lambdaisland.glogi/logger` in 1.0.100 seems to unintentionally set the level of the logger to `nil` when called with a single argument:

```clojure
l.glogi> (logger "" (:config levels))
#js{:getName #object[getName], :__glogi_handlers__ {#object[Function] #object[log_record_handler]}}
l.glogi> (glog/getLevel root-logger)
#object[Level CONFIG]
l.glogi> (logger "")
#js{:getName #object[getName], :__glogi_handlers__ {#object[Function] #object[log_record_handler]}}
l.glogi> (glog/getLevel root-logger)
nil
```
This is done to the root logger when the namespace is first loaded (via `(def root-logger (logger ""))`), leading to various issues:
https://github.com/bhauman/figwheel-main/issues/289

This change passes `js/undefined` to `goog.log/getLogger` instead of `nil` to keep the original level of the logger intact.