### PR TITLE
Update orb from temporary RC orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  clojure: lambdaisland/clojure@dev:0.0.5-rc1
+  clojure: lambdaisland/clojure@dev:0.0.6
 
 commands:
   checkout_and_run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  clojure: lambdaisland/clojure@dev:0.0.6
+  clojure: lambdaisland/clojure@0.0.6
 
 commands:
   checkout_and_run:


### PR DESCRIPTION
A while ago, I created a test Clojure orb, clojure@dev:0.0.5-rc1 because I wasn't sure if my changes for `0.0.5` worked. This is a dev orb, so it expires after a while, but I never updated it. So now I'm updating it to the latest orb.