### PR TITLE
(deprecated classes): remove inexistent reference to goog.debug.LogBu…

### DIFF
--- a/src/lambdaisland/glogi/console.cljs
+++ b/src/lambdaisland/glogi/console.cljs
@@ -2,7 +2,6 @@
   (:require [lambdaisland.glogi :as glogi]
             [lambdaisland.glogi.print :as print]
             [goog.object :as gobj]
-            [goog.debug.LogBuffer :as LogBuffer]
             [goog.debug.Console :as Console]))
 
 ;; By default we do CSS colorization on non-IE browsers only. You can change


### PR DESCRIPTION
There is a blocking compilation error when building in release mode.

`The required namespace "goog.debug.LogBuffer" is not available, it was required by "lambdaisland/glogi/console.cljs".`