### PR TITLE
(externs inference): add a type hint for the Console instance

### DIFF
--- a/src/lambdaisland/glogi/console.cljs
+++ b/src/lambdaisland/glogi/console.cljs
@@ -75,7 +75,7 @@
 (defn install! []
   ;; Disable goog.debug.Console if it's been enabled (e.g. by Figwheel), we do
   ;; console logging now
-  (when-let [instance Console/instance]
+  (when-let [^js instance Console/instance]
     (.setCapturing instance false))
 
   (glogi/add-handler-once (select-handler)))


### PR DESCRIPTION
There is a warning when compiling in release mode
`
  75 |   ;; Disable goog.debug.Console if it's been enabled (e.g. by Figwheel), we do
  76 |   ;; console logging now
  77 |   (when-let [instance Console/instance]
  78 |     (.setCapturing instance false))
-----------^--------------------------------------------------------------------
 Cannot infer target type in expression (. instance setCapturing false)
--------------------------------------------------------------------------------
  79 |
  80 |   (glogi/add-handler-once (select-handler)))
  81 |
--------------------------------------------------------------------------------
`