### PR TITLE
Support passing multiple values to spy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- Add support for logging multiple forms with `spy`.
+
 ## Fixed
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ wrap any expression you want to see the value. Spy expressions are logged at the
 [my.ns] {:spy (+ x x) :=> 4}
 ```
 
+If you pass multiple values to spy, all will be printed:
+
+``` clojure
+(let [x (+ 1 1)
+      y (spy x (+ x x))]
+  (+ x y))
+;;=> 6
+```
+
+```
+[my.ns] {:spy [x 2 (+ x x) 4]}
+```
+
 ### Special keys
 
 Two keywords have a special meaning in logging calls.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ wrap any expression you want to see the value. Spy expressions are logged at the
 [my.ns] {:spy (+ x x) :=> 4}
 ```
 
-As you may have noticed that, unlike `js/console.log` or `prn`, `spy` returns
+As you may have noticed, unlike `js/console.log` or `prn`, `spy` returns
 the value of the expression so you can wrap expressions with it without
 disrupting the flow of your program.
 
@@ -186,12 +186,15 @@ If you pass multiple values to spy, all will be printed:
 [my.ns] {:spy [host "localhost" port 8080]}
 ```
 
-This will be logged slighly diferently on Clojure, due to Glogc being a thin wrapper
-and Pedestal not supporting multiple values:
+This will be logged slighly diferently on Clojure. This is because Pedestal
+doesn't directly support multiple values to spy, and Glogc tries to be a
+thin wrapper:
 
 ```
-[my.ns] {:spy [host port] :value [ "localhost"8080]}
+[my.ns] {:spy [host port] :value ["localhost" 8080]}
 ```
+If you call spy on multiple values, the last value will be returned, analogous
+to `do`.
 
 ### Special keys
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ If you pass multiple values to spy, all will be printed:
 [my.ns] {:spy [host "localhost" port 8080]}
 ```
 
+This will be logged slighly diferently on Clojure, due to Glogc being a thin wrapper
+and Pedestal not supporting multiple values:
+
+```
+[my.ns] {:spy [host port] :value [ "localhost"8080]}
+```
+
 ### Special keys
 
 Two keywords have a special meaning in logging calls.

--- a/README.md
+++ b/README.md
@@ -169,17 +169,21 @@ wrap any expression you want to see the value. Spy expressions are logged at the
 [my.ns] {:spy (+ x x) :=> 4}
 ```
 
+As you may have noticed that, unlike `js/console.log` or `prn`, `spy` returns
+the value of the expression so you can wrap expressions with it without
+disrupting the flow of your program.
+
 If you pass multiple values to spy, all will be printed:
 
 ``` clojure
-(let [x (+ 1 1)
-      y (spy x (+ x x))]
-  (+ x y))
-;;=> 6
+(fn [{:keys [host port path protocol] :as config}]
+  (spy host port)
+  ;;...
+  )
 ```
 
 ```
-[my.ns] {:spy [x 2 (+ x x) 4]}
+[my.ns] {:spy [host "localhost" port 8080]}
 ```
 
 ### Special keys

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -4,7 +4,7 @@ set -ex
 
 [ -d node_modules/ws ] || npm install ws
 
-clojure -A:dev:test:cljs764 -M -m kaocha.runner "$@"
-clojure -A:dev:test:cljs844 -M -m kaocha.runner "$@"
-clojure -A:dev:test:cljs896 -M -m kaocha.runner "$@"
-clojure -A:dev:test:cljs-latest -M -m kaocha.runner "$@"
+clojure -A:dev:pedestal:test:cljs764 -M -m kaocha.runner "$@"
+clojure -A:dev:pedestal:test:cljs844 -M -m kaocha.runner "$@"
+clojure -A:dev:pedestal:test:cljs896 -M -m kaocha.runner "$@"
+clojure -A:dev:pedestal:test:cljs-latest -M -m kaocha.runner "$@"

--- a/src/lambdaisland/glogc.cljc
+++ b/src/lambdaisland/glogc.cljc
@@ -56,7 +56,7 @@
         (target :clj `(pedestal/spy ~expr)
                 :cljs `(glogi/spy ~expr)))
        ([expr & exprs]
-        (target :clj `(pedestal/spy ~expr)
+        (target :clj `(pedestal/spy [ ~expr ~@exprs])
                 :cljs `(glogi/spy ~expr ~@exprs))))
 
      (defmacro with-context [ctx-map & body]

--- a/src/lambdaisland/glogc.cljc
+++ b/src/lambdaisland/glogc.cljc
@@ -56,7 +56,7 @@
         (target :clj `(pedestal/spy ~expr)
                 :cljs `(glogi/spy ~expr)))
        ([expr & exprs]
-        (target :clj `(pedestal/spy [ ~expr ~@exprs])
+        (target :clj `(last (pedestal/spy [ ~expr ~@exprs]))
                 :cljs `(glogi/spy ~expr ~@exprs))))
 
      (defmacro with-context [ctx-map & body]

--- a/src/lambdaisland/glogc.cljc
+++ b/src/lambdaisland/glogc.cljc
@@ -51,9 +51,13 @@
        (target :clj  (#'pedestal/log-expr &form :error keyvals)
                :cljs (#'glogi/log-expr &form :error keyvals)))
 
-     (defmacro spy [expr]
-       (target :clj `(pedestal/spy ~expr)
-               :cljs `(glogi/spy ~expr)))
+     (defmacro spy
+       ([expr]
+        (target :clj `(pedestal/spy ~expr)
+                :cljs `(glogi/spy ~expr)))
+       ([expr & exprs]
+        (target :clj `(pedestal/spy ~expr)
+                :cljs `(glogi/spy ~expr ~@exprs))))
 
      (defmacro with-context [ctx-map & body]
        `(pedestal/with-context ~ctx-map ~@body))

--- a/src/lambdaisland/glogi.clj
+++ b/src/lambdaisland/glogi.clj
@@ -53,7 +53,7 @@
         ~res)))
   ([form & forms]
    (let [form-res (mapv (fn [f] (let [res (gensym)] (vector f res))) (conj forms form))
-         form-res-dict (into [] (mapcat (fn [[k v]] [k v]) form-res))]
+         form-res-dict (into [] (mapcat (fn [[k v]] [`'~k v]) form-res))]
      `(let ~(into [] (mapcat (fn [[k v]] [v k]) form-res))
         ~(log-expr &form :debug [:spy form-res-dict])
-        ~(last form-res)))))
+        ~(last (last form-res))))))

--- a/src/lambdaisland/glogi.clj
+++ b/src/lambdaisland/glogi.clj
@@ -44,9 +44,16 @@
 (defmacro finest [& keyvals]
   (log-expr &form :finest keyvals))
 
-(defmacro spy [form]
-  (let [res (gensym)]
-    `(let [~res ~form]
-       ~(log-expr &form :debug [:spy `'~form
-                                :=> res])
-       ~res)))
+(defmacro spy
+  ([form]
+   (let [res (gensym)]
+     `(let [~res ~form]
+        ~(log-expr &form :debug [:spy `'~form
+                                 :=> res])
+        ~res)))
+  ([form & forms]
+   (let [form-res (mapv (fn [f] (let [res (gensym)] (vector f res))) (conj forms form))
+         form-res-dict (into [] (mapcat (fn [[k v]] [k v]) form-res))]
+     `(let ~(into [] (mapcat (fn [[k v]] [v k]) form-res))
+        ~(log-expr &form :debug [:spy form-res-dict])
+        ~(last form-res)))))

--- a/test/lambdaisland/glogc_test.cljs
+++ b/test/lambdaisland/glogc_test.cljs
@@ -1,4 +1,3 @@
-
 (ns lambdaisland.glogc-test
   (:require [lambdaisland.glogc :as logc]
             [lambdaisland.glogi :as log]
@@ -7,10 +6,25 @@
 (enable-console-print!)
 
 (deftest smoke-test
-  (let [example-val 5]
+  (let [captured (atom [])
+        handler (fn [record] (swap! captured conj record))
+        example-val 5]
+    (log/add-handler handler)
+    (log/set-levels '{lambdaisland.glogc-test :info})
     (logc/warn :get :these :log :messages)
     (logc/fine :not :you)
     (logc/info :to :show :up :here)
     (is (= example-val (logc/spy example-val)))
-    (is (= :spy1 (logc/spy :spy1 example-val)))))
+    (is (= example-val (logc/spy :spy1 example-val)))
+    (is (= [{:sequenceNumber 0
+             :level :warning
+             :message {:get :these :log :messages :line 14}
+             :logger-name "lambdaisland.glogc-test"
+             :exception nil}
+            {:sequenceNumber 0
+             :level :info
+             :message {:to :show :up :here :line 16}
+             :logger-name "lambdaisland.glogc-test" :exception nil}]
+           (map #(dissoc % :time) @captured)))
+    (log/remove-handler handler)))
 

--- a/test/lambdaisland/glogc_test.cljs
+++ b/test/lambdaisland/glogc_test.cljs
@@ -1,0 +1,16 @@
+
+(ns lambdaisland.glogc-test
+  (:require [lambdaisland.glogc :as logc]
+            [lambdaisland.glogi :as log]
+            [clojure.test :refer [deftest testing is are use-fixtures run-tests join-fixtures]]))
+
+(enable-console-print!)
+
+(deftest smoke-test
+  (let [example-val 5]
+    (logc/warn :get :these :log :messages)
+    (logc/fine :not :you)
+    (logc/info :to :show :up :here)
+    (is (= example-val (logc/spy example-val)))
+    (is (= :spy1 (logc/spy :spy1 example-val)))))
+

--- a/test/lambdaisland/glogi_test.cljs
+++ b/test/lambdaisland/glogi_test.cljs
@@ -27,6 +27,5 @@
     (log/spy example-val)
     (log/spy :spy1 example-val)
     (log/remove-handler handler)
-
     (is (= (log/level-value :warn) 900))))
 

--- a/test/lambdaisland/glogi_test.cljs
+++ b/test/lambdaisland/glogi_test.cljs
@@ -6,7 +6,8 @@
 
 (deftest smoke-test
   (let [captured (atom [])
-        handler (fn [record] (swap! captured conj record))]
+        handler (fn [record] (swap! captured conj record))
+        example-val 5]
     (log/add-handler handler)
     (log/set-levels '{lambdaisland.glogi-test :info})
     (log/warn :get :these :log :messages)
@@ -14,14 +15,17 @@
     (log/info :to :show :up :here)
     (is (= [{:sequenceNumber 0
              :level :warning
-             :message {:get :these :log :messages :line 12}
+             :message {:get :these :log :messages :line 13}
              :logger-name "lambdaisland.glogi-test"
              :exception nil}
             {:sequenceNumber 0
              :level :info
-             :message {:to :show :up :here :line 14}
+             :message {:to :show :up :here :line 15}
              :logger-name "lambdaisland.glogi-test" :exception nil}]
            (map #(dissoc % :time) @captured)))
+    (log/set-levels '{lambdaisland.glogi-test :debug}) ;Debug covers spy
+    (log/spy :spy)
+    (log/spy :spy1 example-val)
     (log/remove-handler handler)
 
     (is (= (log/level-value :warn) 900))))

--- a/test/lambdaisland/glogi_test.cljs
+++ b/test/lambdaisland/glogi_test.cljs
@@ -24,8 +24,9 @@
              :logger-name "lambdaisland.glogi-test" :exception nil}]
            (map #(dissoc % :time) @captured)))
     (log/set-levels '{lambdaisland.glogi-test :debug}) ;Debug covers spy
-    (log/spy :spy)
+    (log/spy example-val)
     (log/spy :spy1 example-val)
     (log/remove-handler handler)
 
     (is (= (log/level-value :warn) 900))))
+


### PR DESCRIPTION
I often want to pass multiple values to spy, so I added that capability to the macro.

Having worked on this PR, I think the intended usage is wrapping existing expressions with `spy`, which avoids the need for passing multiple values to spy. Still, I think using spy with multiple values is sometimes useful even if you predominantly wrap existing forms.