### PR TITLE
Wrap `log-expr` in a conditional to assist DCE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Changed
 
+- Modified an internal function so that code emitted by logging macros can be
+  DCE'd when the user disables logging.
+
 # 1.2.164 (2022-11-25 / 9a89583)
 
 ## Added

--- a/src/lambdaisland/glogi.clj
+++ b/src/lambdaisland/glogi.clj
@@ -3,13 +3,14 @@
 (defn- log-expr [form level keyvals]
   (let [keyvals-map (apply array-map keyvals)
         formatter (::formatter keyvals-map 'identity)]
-    `(log ~(::logger keyvals-map (str *ns*))
-          ~level
-          (~formatter
-           ~(-> keyvals-map
-                (dissoc ::logger)
-                (assoc :line (:line (meta form)))))
-          ~(:exception keyvals-map))))
+    `(when ~(with-meta 'goog.debug.LOGGING_ENABLED {:tag 'boolean})
+       (log ~(::logger keyvals-map (str *ns*))
+            ~level
+            (~formatter
+             ~(-> keyvals-map
+                  (dissoc ::logger)
+                  (assoc :line (:line (meta form)))))
+            ~(:exception keyvals-map)))))
 
 (defmacro shout [& keyvals]
   (log-expr &form :shout keyvals))


### PR DESCRIPTION
Fixes #26. This allows code from macros like `trace`, `debug`, etc. to be removed by GCC when the user has the compiler constant `goog.debug.LOGGING_ENABLED` set to `false`.