### PR TITLE
allow passing in :line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Changed
 
+- Update passed in `:line` to take precedence over metadata's `:line`
+
 # 1.3.169 (2023-03-27 / 109b82e)
 
 ## Added

--- a/src/lambdaisland/glogi.clj
+++ b/src/lambdaisland/glogi.clj
@@ -2,14 +2,15 @@
 
 (defn- log-expr [form level keyvals]
   (let [keyvals-map (apply array-map keyvals)
-        formatter (::formatter keyvals-map 'identity)]
+        formatter (::formatter keyvals-map 'identity)
+        line (:line keyvals-map (:line (meta form)))]
     `(when ~(with-meta 'goog.debug.LOGGING_ENABLED {:tag 'boolean})
        (log ~(::logger keyvals-map (str *ns*))
             ~level
             (~formatter
              ~(-> keyvals-map
                   (dissoc ::logger)
-                  (assoc :line (:line (meta form)))))
+                  (assoc :line line)))
             ~(:exception keyvals-map)))))
 
 (defmacro shout [& keyvals]

--- a/test/lambdaisland/glogi_test.cljs
+++ b/test/lambdaisland/glogi_test.cljs
@@ -13,6 +13,7 @@
     (log/warn :get :these :log :messages)
     (log/fine :not :you)
     (log/info :to :show :up :here)
+    (log/info :over :ride :line -1)
     (is (= [{:sequenceNumber 0
              :level :warning
              :message {:get :these :log :messages :line 13}
@@ -21,6 +22,10 @@
             {:sequenceNumber 0
              :level :info
              :message {:to :show :up :here :line 15}
+             :logger-name "lambdaisland.glogi-test" :exception nil}
+            {:sequenceNumber 0
+             :level :info
+             :message {:over :ride :line -1}
              :logger-name "lambdaisland.glogi-test" :exception nil}]
            (map #(dissoc % :time) @captured)))
     (log/set-levels '{lambdaisland.glogi-test :debug}) ;Debug covers spy


### PR DESCRIPTION
👋  Hello! Thanks for all your work on this library! My reasoning for this PR is that I sometimes will add `log/*` to a macro. Inside of my macro, the `&form` is accessible however it's not accessible to `log-expr` in `lambdaisland.glogi`. This allows me to pass `:line` in as part of the macro and not have it overridden with `nil`. Thanks and let me know if you'd like any changes!